### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/backend/src/api/routes/pods.ts
+++ b/backend/src/api/routes/pods.ts
@@ -62,7 +62,7 @@ export function createPodsRouter(stateManager: StateManager): Router {
 
       res.json(pod);
     } catch (error) {
-      console.error(`Failed to get pod ${req.params.podName}:`, error);
+      console.error('Failed to get pod %s:', req.params.podName, error);
       res.status(500).json({
         error: 'INTERNAL_ERROR',
         message: 'Failed to retrieve pod details',


### PR DESCRIPTION
Potential fix for [https://github.com/stianfro/threek8s/security/code-scanning/3](https://github.com/stianfro/threek8s/security/code-scanning/3)

The best practice is to use a static string as the format message, and pass any user-controlled data as arguments to the logging function, ensuring that no untrusted data is interpreted as part of a format string. Here, instead of using a template literal that mixes user input with a constant string for the log message, we should pass a static format string (e.g., `'Failed to get pod %s:'`) and provide the user input (`req.params.podName`) as a separate argument. This ensures that any format specifiers are properly handled and user input cannot be interpreted as part of the format string.  

Specifically, in `backend/src/api/routes/pods.ts`, line 65 should be changed from:
```ts
console.error(`Failed to get pod ${req.params.podName}:`, error);
```
to:
```ts
console.error('Failed to get pod %s:', req.params.podName, error);
```
No imports or additional methods are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
