### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/backend/src/api/routes/nodes.ts
+++ b/backend/src/api/routes/nodes.ts
@@ -60,7 +60,7 @@ export function createNodesRouter(stateManager: StateManager): Router {
         }))
       });
     } catch (error) {
-      console.error(`Failed to get node ${req.params.nodeName}:`, error);
+      console.error('Failed to get node %s:', req.params.nodeName, error);
       res.status(500).json({
         error: 'INTERNAL_ERROR',
         message: 'Failed to retrieve node details',


### PR DESCRIPTION
Potential fix for [https://github.com/stianfro/threek8s/security/code-scanning/2](https://github.com/stianfro/threek8s/security/code-scanning/2)

To fix the problem, the untrusted input—`req.params.nodeName`—should not be embedded directly into the format string passed as the first argument to `console.error` if additional parameters are present. Instead, use a constant format string and pass untrusted data as a separate argument. For example, change:

```js
console.error(`Failed to get node ${req.params.nodeName}:`, error);
```

to

```js
console.error('Failed to get node %s:', req.params.nodeName, error);
```

This guarantees that even if the user passes unexpected format specifiers, it will be treated as plain data.

Only edit the line in file `backend/src/api/routes/nodes.ts` at line 63.

No additional imports, methods, or variable definitions are needed: only a code edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
