### PR TITLE
feat: add kiosk token authentication for kiosk systems

### DIFF
--- a/backend/src/config/oidc.ts
+++ b/backend/src/config/oidc.ts
@@ -10,6 +10,7 @@ export interface OidcConfig {
   issuer: string;
   audience: string;
   jwksUri: string;
+  kioskAuthToken?: string;
 }
 
 /**
@@ -17,6 +18,7 @@ export interface OidcConfig {
  */
 export function loadOidcConfig(): OidcConfig {
   const enabled = process.env.AUTH_ENABLED === "true";
+  const kioskAuthToken = process.env.KIOSK_AUTH_TOKEN;
 
   if (!enabled) {
     console.log("Authentication is disabled (AUTH_ENABLED=false)");
@@ -25,6 +27,7 @@ export function loadOidcConfig(): OidcConfig {
       issuer: "",
       audience: "",
       jwksUri: "",
+      kioskAuthToken,
     };
   }
 
@@ -32,21 +35,31 @@ export function loadOidcConfig(): OidcConfig {
   const audience = process.env.OIDC_AUDIENCE || "";
   const jwksUri = process.env.OIDC_JWKS_URI || "";
 
-  // Validate required fields when auth is enabled
-  if (!issuer || !audience || !jwksUri) {
+  // Check if either OIDC or kiosk auth is configured
+  const hasOidcConfig = issuer && audience && jwksUri;
+  const hasKioskAuth = kioskAuthToken && kioskAuthToken.length > 0;
+
+  if (!hasOidcConfig && !hasKioskAuth) {
     throw new Error(
-      "OIDC configuration incomplete. When AUTH_ENABLED=true, you must set: OIDC_ISSUER, OIDC_AUDIENCE, OIDC_JWKS_URI",
+      "Authentication configuration incomplete. When AUTH_ENABLED=true, you must set either: " +
+        "(OIDC_ISSUER, OIDC_AUDIENCE, OIDC_JWKS_URI) or KIOSK_AUTH_TOKEN",
     );
   }
 
   console.log("Authentication is enabled");
-  console.log(`OIDC Issuer: ${issuer}`);
-  console.log(`OIDC Audience: ${audience}`);
+  if (hasOidcConfig) {
+    console.log(`OIDC Issuer: ${issuer}`);
+    console.log(`OIDC Audience: ${audience}`);
+  }
+  if (hasKioskAuth) {
+    console.log("Kiosk authentication token configured");
+  }
 
   return {
     enabled: true,
     issuer,
     audience,
     jwksUri,
+    kioskAuthToken,
   };
 }

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -20,6 +20,7 @@ export class AuthService {
   private config: AuthConfig;
   private currentUser: User | null = null;
   private authChangeCallbacks: Array<(user: User | null) => void> = [];
+  private kioskToken: string | null = null;
 
   constructor(config: AuthConfig) {
     this.config = config;
@@ -150,6 +151,10 @@ export class AuthService {
    * Get access token
    */
   getAccessToken(): string | null {
+    // Return kiosk token if set (takes precedence)
+    if (this.kioskToken) {
+      return this.kioskToken;
+    }
     return this.currentUser?.access_token || null;
   }
 
@@ -159,6 +164,10 @@ export class AuthService {
   isAuthenticated(): boolean {
     if (!this.config.enabled) {
       return true; // When auth is disabled, consider everyone authenticated
+    }
+    // Check kiosk token first
+    if (this.kioskToken) {
+      return true;
     }
     return this.currentUser !== null && !this.currentUser.expired;
   }
@@ -200,5 +209,18 @@ export class AuthService {
       console.error("Token renewal failed:", error);
       throw error;
     }
+  }
+
+  /**
+   * Set kiosk authentication token
+   * Used for URL-based authentication in kiosk environments
+   */
+  setKioskToken(token: string): void {
+    if (!token || token.trim().length === 0) {
+      console.warn("Invalid kiosk token provided");
+      return;
+    }
+    this.kioskToken = token.trim();
+    console.log("Kiosk authentication token set");
   }
 }


### PR DESCRIPTION
## Summary
Add support for URL-based token authentication as an alternative to OIDC login flow for kiosk environments where interactive login is impractical/impossible.

## Changes

### Backend
- **config/oidc.ts**: Add `KIOSK_AUTH_TOKEN` environment variable support
- **services/TokenValidator.ts**: Validate kiosk tokens using constant-time comparison to prevent timing attacks
- Support either OIDC JWT or kiosk token authentication (both methods work side-by-side)

### Frontend
- **services/AuthService.ts**: Add `setKioskToken()` method and kiosk token mode support
- **main.ts**: Extract token from `?token=<value>` URL parameter and automatically remove it from browser history

## Usage

**1. Configure backend:**
```bash
# Set a long-lived secret token
KIOSK_AUTH_TOKEN=your-secure-random-token
AUTH_ENABLED=true

# OIDC config now optional when using kiosk token
```

**2. Generate secure token:**
```bash
# Example: Generate 32-byte hex token (16 chars)
openssl rand -hex 8

# Or using Node.js
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
```

**3. Kiosk access:**
```
https://your-app-url/?token=your-secure-random-token
```

The token is automatically extracted from URL and removed from browser history for security.

## Security Notes
- Constant-time token comparison prevents timing attacks
- Rate limiting (100 req/15min) protects against brute force
- Token removed from URL immediately after extraction
- Recommended: 12-16 character tokens for balance of security/usability
- Both OIDC and kiosk auth can be used simultaneously

## Test plan
- [ ] Test with kiosk token authentication
- [ ] Verify OIDC still works when both configured
- [ ] Verify authentication fails with invalid token
- [ ] Verify token is removed from URL after extraction
- [ ] Test rate limiting protects against brute force

🤖 Generated with [Claude Code](https://claude.com/claude-code)